### PR TITLE
Flow kernel class name and fix kernelspec templates

### DIFF
--- a/remote_provisioners/kernel-launchers/bootstrap/bootstrap-kernel.sh
+++ b/remote_provisioners/kernel-launchers/bootstrap/bootstrap-kernel.sh
@@ -5,23 +5,33 @@ RESPONSE_ADDRESS=${RESPONSE_ADDRESS:-${EG_RESPONSE_ADDRESS}}
 PUBLIC_KEY=${PUBLIC_KEY:-${EG_PUBLIC_KEY}}
 KERNEL_LAUNCHERS_DIR=${KERNEL_LAUNCHERS_DIR:-${install_dir}/kernel-launchers}
 KERNEL_SPARK_CONTEXT_INIT_MODE=${KERNEL_SPARK_CONTEXT_INIT_MODE:-none}
+KERNEL_CLASS_NAME=${KERNEL_CLASS_NAME}
 
 echo $0 env: `env`
 
 launch_python_kernel() {
-    # Launch the python kernel launcher - which embeds the IPython kernel and listens for interrupts
-    # and shutdown requests from Enterprise Gateway.
+  # Launch the python kernel launcher - which embeds the IPython kernel and listens for interrupts
+  # and shutdown requests from the server.
 
-    export JPY_PARENT_PID=$$$$  # Force reset of parent pid since we're detached
+  export JPY_PARENT_PID=$$$$  # Force reset of parent pid since we're detached
+
+  if [ -z "${KERNEL_CLASS_NAME}" ]
+  then
+    kernel_class_option = ""
+  else
+    kernel_class_option = "--kernel_class_name ${KERNEL_CLASS_NAME}"
+  fi
 
 	set -x
-	python ${KERNEL_LAUNCHERS_DIR}/python/scripts/launch_ipykernel.py --kernel-id ${KERNEL_ID} --port-range ${PORT_RANGE} --response-address ${RESPONSE_ADDRESS} --public-key ${PUBLIC_KEY} --spark-context-initialization-mode ${KERNEL_SPARK_CONTEXT_INIT_MODE}
+	python ${KERNEL_LAUNCHERS_DIR}/python/scripts/launch_ipykernel.py --kernel-id ${KERNEL_ID} \
+	      --port-range ${PORT_RANGE} --response-address ${RESPONSE_ADDRESS} --public-key ${PUBLIC_KEY} \
+	      --spark-context-initialization-mode ${KERNEL_SPARK_CONTEXT_INIT_MODE}  ${kernel_class_option}
 	{ set +x; } 2>/dev/null
 }
 
 launch_R_kernel() {
     # Launch the R kernel launcher - which embeds the IRkernel kernel and listens for interrupts
-    # and shutdown requests from Enterprise Gateway.
+    # and shutdown requests from the server.
 
 	set -x
 	Rscript ${KERNEL_LAUNCHERS_DIR}/R/scripts/launch_IRkernel.R --kernel-id ${KERNEL_ID} --port-range ${PORT_RANGE} --response-address ${RESPONSE_ADDRESS} --public-key ${PUBLIC_KEY} --spark-context-initialization-mode ${KERNEL_SPARK_CONTEXT_INIT_MODE}
@@ -30,7 +40,7 @@ launch_R_kernel() {
 
 launch_scala_kernel() {
     # Launch the scala kernel launcher - which embeds the Apache Toree kernel and listens for interrupts
-    # and shutdown requests from Enterprise Gateway.  This kernel is currenly always launched using
+    # and shutdown requests from the server.  This kernel is currenly always launched using
     # spark-submit, so additional setup is required.
 
     PROG_HOME=${KERNEL_LAUNCHERS_DIR}/scala

--- a/remote_provisioners/kernel-launchers/docker/scripts/launch_docker.py
+++ b/remote_provisioners/kernel-launchers/docker/scripts/launch_docker.py
@@ -15,7 +15,9 @@ remove_container = bool(
 swarm_mode = bool(os.getenv("DOCKER_MODE", os.getenv("RP_DOCKER_MODE", "swarm")).lower() == "swarm")
 
 
-def launch_docker_kernel(kernel_id, port_range, response_addr, public_key, spark_context_init_mode):
+def launch_docker_kernel(
+    kernel_id, port_range, response_addr, public_key, spark_context_init_mode, kernel_class_name
+):
     # Launches a containerized kernel.
 
     # Can't proceed if no image was specified.
@@ -41,6 +43,8 @@ def launch_docker_kernel(kernel_id, port_range, response_addr, public_key, spark
     param_env["PUBLIC_KEY"] = public_key
     param_env["RESPONSE_ADDRESS"] = response_addr
     param_env["KERNEL_SPARK_CONTEXT_INIT_MODE"] = spark_context_init_mode
+    if kernel_class_name:
+        param_env["KERNEL_CLASS_NAME"] = kernel_class_name
 
     # Since the environment is specific to the kernel (per env stanza of kernelspec, KERNEL_ and EG_CLIENT_ENVS)
     # just add the env here.
@@ -136,12 +140,20 @@ if __name__ == "__main__":
         help="Indicates whether or how a spark context should be created",
         default="none",
     )
-
+    parser.add_argument(
+        "--kernel-class-name",
+        dest="kernel_class_name",
+        nargs="?",
+        help="Indicates the name of the kernel class to use.  Must be a subclass of 'ipykernel.kernelbase.Kernel'.",
+    )
     arguments = vars(parser.parse_args())
     kernel_id = arguments["kernel_id"]
     port_range = arguments["port_range"]
     response_addr = arguments["response_address"]
     public_key = arguments["public_key"]
     spark_context_init_mode = arguments["spark_context_init_mode"]
+    kernel_class_name = arguments["kernel_class_name"]
 
-    launch_docker_kernel(kernel_id, port_range, response_addr, public_key, spark_context_init_mode)
+    launch_docker_kernel(
+        kernel_id, port_range, response_addr, public_key, spark_context_init_mode, kernel_class_name
+    )

--- a/remote_provisioners/kernel-launchers/kubernetes/scripts/launch_kubernetes.py
+++ b/remote_provisioners/kernel-launchers/kubernetes/scripts/launch_kubernetes.py
@@ -51,6 +51,7 @@ def launch_kubernetes_kernel(
     spark_context_init_mode,
     pod_template_file,
     spark_opts_out,
+    kernel_class_name,
 ):
     # Launches a containerized kernel as a kubernetes pod.
 
@@ -71,6 +72,7 @@ def launch_kubernetes_kernel(
     keywords["kernel_id"] = kernel_id
     keywords["kernel_name"] = os.path.basename(os.path.dirname(os.path.dirname(__file__)))
     keywords["kernel_spark_context_init_mode"] = spark_context_init_mode
+    keywords["kernel_class_name"] = kernel_class_name
 
     # Walk env variables looking for names prefixed with KERNEL_.  When found, set corresponding keyword value
     # with name in lower case.
@@ -239,6 +241,12 @@ if __name__ == "__main__":
         help="When present, additional spark options are written to file, "
         "no launch performed, requires --pod-template.",
     )
+    parser.add_argument(
+        "--kernel-class-name",
+        dest="kernel_class_name",
+        nargs="?",
+        help="Indicates the name of the kernel class to use.  Must be a subclass of 'ipykernel.kernelbase.Kernel'.",
+    )
 
     arguments = vars(parser.parse_args())
     kernel_id = arguments["kernel_id"]
@@ -248,6 +256,7 @@ if __name__ == "__main__":
     spark_context_init_mode = arguments["spark_context_init_mode"]
     pod_template_file = arguments["pod_template_file"]
     spark_opts_out = arguments["spark_opts_out"]
+    kernel_class_name = arguments["kernel_class_name"]
 
     launch_kubernetes_kernel(
         kernel_id,
@@ -257,4 +266,5 @@ if __name__ == "__main__":
         spark_context_init_mode,
         pod_template_file,
         spark_opts_out,
+        kernel_class_name,
     )

--- a/remote_provisioners/kernel-specs/k8s_python_spark/kernel.json
+++ b/remote_provisioners/kernel-specs/k8s_python_spark/kernel.json
@@ -22,6 +22,8 @@
     "{kernel_id}",
     "--response-address",
     "{response_address}",
+    "--public-key",
+    "{public_key}",
     "--spark-context-initialization-mode",
     "${spark_init_mode}",
     "--kernel-class-name",

--- a/remote_provisioners/kernel-specs/ssh_python_spark/kernel.json
+++ b/remote_provisioners/kernel-specs/ssh_python_spark/kernel.json
@@ -17,15 +17,17 @@
   },
   "argv": [
     "${install_dir}/bin/run.sh",
-    "--RemoteProcessProxy.kernel-id",
+    "--kernel-id",
     "{kernel_id}",
-    "--RemoteProcessProxy.response-address",
+    "--response-address",
     "{response_address}",
-    "--RemoteProcessProxy.public-key",
+    "--public-key",
     "{public_key}",
-    "--RemoteProcessProxy.port-range",
+    "--port-range",
     "{port_range}",
-    "--RemoteProcessProxy.spark-context-initialization-mode",
-    "${spark_init_mode}"
+    "--spark-context-initialization-mode",
+    "${spark_init_mode}",
+    "--kernel-class-name",
+    "${ipykernel_subclass_name}"
   ]
 }

--- a/remote_provisioners/kernel-specs/ssh_r/kernel.json
+++ b/remote_provisioners/kernel-specs/ssh_r/kernel.json
@@ -11,13 +11,13 @@
   "argv": [
     "Rscript",
     "${install_dir}/scripts/launch_IRkernel.R",
-    "--RemoteProcessProxy.kernel-id",
+    "--kernel-id",
     "{kernel_id}",
-    "--RemoteProcessProxy.response-address",
+    "--response-address",
     "{response_address}",
-    "--RemoteProcessProxy.public-key",
+    "--public-key",
     "{public_key}",
-    "--RemoteProcessProxy.port-range",
+    "--port-range",
     "{port_range}"
   ]
 }

--- a/remote_provisioners/kernel-specs/ssh_r_spark/kernel.json
+++ b/remote_provisioners/kernel-specs/ssh_r_spark/kernel.json
@@ -14,15 +14,15 @@
   },
   "argv": [
     "${install_dir}/bin/run.sh",
-    "--RemoteProcessProxy.kernel-id",
+    "--kernel-id",
     "{kernel_id}",
-    "--RemoteProcessProxy.response-address",
+    "--response-address",
     "{response_address}",
-    "--RemoteProcessProxy.public-key",
+    "--public-key",
     "{public_key}",
-    "--RemoteProcessProxy.port-range",
+    "--port-range",
     "{port_range}",
-    "--RemoteProcessProxy.spark-context-initialization-mode",
+    "--spark-context-initialization-mode",
     "${spark_init_mode}"
   ]
 }

--- a/remote_provisioners/kernel-specs/ssh_scala/kernel.json
+++ b/remote_provisioners/kernel-specs/ssh_scala/kernel.json
@@ -14,13 +14,13 @@
   },
   "argv": [
     "${install_dir}/bin/run.sh",
-    "--RemoteProcessProxy.kernel-id",
+    "--kernel-id",
     "{kernel_id}",
-    "--RemoteProcessProxy.response-address",
+    "--response-address",
     "{response_address}",
-    "--RemoteProcessProxy.public-key",
+    "--public-key",
     "{public_key}",
-    "--RemoteProcessProxy.port-range",
+    "--port-range",
     "{port_range}"
   ]
 }

--- a/remote_provisioners/kernel-specs/ssh_scala_spark/kernel.json
+++ b/remote_provisioners/kernel-specs/ssh_scala_spark/kernel.json
@@ -15,15 +15,15 @@
   },
   "argv": [
     "${install_dir}/bin/run.sh",
-    "--RemoteProcessProxy.kernel-id",
+    "--kernel-id",
     "{kernel_id}",
-    "--RemoteProcessProxy.response-address",
+    "--response-address",
     "{response_address}",
-    "--RemoteProcessProxy.public-key",
+    "--public-key",
     "{public_key}",
-    "--RemoteProcessProxy.port-range",
+    "--port-range",
     "{port_range}",
-    "--RemoteProcessProxy.spark-context-initialization-mode",
+    "--spark-context-initialization-mode",
     "${spark_init_mode}"
   ]
 }


### PR DESCRIPTION
Just like in EG, the `kernel-class-name` option was not flowing from the container launchers to the containers.  This pull request fixes that.

Also, many of the kernelspec templates still referenced `RemoteProcessProxy` prefixes on their `argv` parameters and one was missing the `public-key`.  These have been fixed in this pull request as well.